### PR TITLE
Fix broken example code and correct typos (#8)

### DIFF
--- a/appointment-booking-service-business-logic-layer.asciidoc
+++ b/appointment-booking-service-business-logic-layer.asciidoc
@@ -6,13 +6,13 @@
 
 In this chapter we are going to create business logic layer for already implemented database queries. We are going to prepare UseCases together with Transfer Objects and corresponding tests.
 
-The chapter contains 4 exercises -- the first two are essential, third and forth exercise are optional, and they can be done in any order.
+The chapter contains 4 exercises -- the first two are essential, the third and fourth exercises are optional, and they can be done in any order.
 
 toc::[]
 
 == Design of the Logic Layer and implementation of the first CRUD Use Cases
 
-To get familiar with the structure of the Business Logic Layer will start with the implementation of very basic CRUD (**C**reate, **R**ead, **U**pdate, **D**elete) logic. We are going to create Transfer Objects, add Use Case Interfaces, implement and test them. If you are familiar with the TDD approach (or just want to try it out) you may try using TDD instead of creating all the tests at the end of this exercise.
+To get familiar with the structure of the Business Logic Layer, we will start with the implementation of very basic CRUD (**C**reate, **R**ead, **U**pdate, **D**elete) logic. We are going to create Transfer Objects, add Use Case Interfaces, implement and test them. If you are familiar with the TDD approach (or just want to try it out) you may try using TDD instead of creating all the tests at the end of this exercise.
 
 === Transfer Objects
 
@@ -35,6 +35,7 @@ public class TreatmentEto  {
     private final Long id;
     private final String name;
     private final String description;
+    private final int durationMinutes;
 }
 ----
 
@@ -223,7 +224,7 @@ class ManageTreatmentUcTestIT extends BaseTest {
 }
 ----
 
-In our case, the above integration tests will be relatively fast. However, to run such test we need to start the application context and the tests themselves will talk to the database, so in the real-live scenarios such tests can be very slow. Fortunately, we should already have our repositories tested, so to test our logic layer we can just mock them:
+In our case, the above integration tests will be relatively fast. However, to run such tests we need to start the application context and the tests themselves will talk to the database, so in real-life scenarios such tests can be very slow. Fortunately, we should already have our repositories tested, so to test our logic layer we can just mock them:
 
 [source,java]
 ----
@@ -303,7 +304,7 @@ NOTE: To facilitate searching by specific criteria, create a separate class or r
 
     List<AppointmentCto> findAll();
 
-    boolean hasConflictingAppointment(Long specialistId, Instant dateTime, Instant endDateTime));
+    boolean hasConflictingAppointment(Long specialistId, Instant dateTime, Instant endDateTime);
 ----
 
 - Create `ManageAppointmentUc` interface with the following methods:

--- a/appointment-booking-service-dataaccess-layer.asciidoc
+++ b/appointment-booking-service-dataaccess-layer.asciidoc
@@ -16,10 +16,10 @@ After you have completed your own link:appointment-booking-service-setup.asciido
 Going back to our example application, link:appointment-booking-system-specification.asciidoc[Appointment Booking System], we need to provide basic functionalities:
 
 - Adding a new `Treatment` associated with a `Specialist`
-- Retrieving a list of available `Treatments`, optionaly filtered by `Specialist` or `Treatment` name
+- Retrieving a list of available `Treatments`, optionally filtered by `Specialist` or `Treatment` name
 - Retrieving the details of a `Treatment` - gathering information from `Treatment` and connected `Specialist`
 - Choosing a `Treatment` as a `Client` and creating an `Appointment` for a given date and hour
-- Validation of `Appointment` date conflict by checking if the date does not colide with other Appointments assigned to a `Specialist` (there can`t be two `Appointments` created for the same `Specialist` at the same time)
+- Validation of `Appointment` date conflict by checking if the date does not collide with other Appointments assigned to a `Specialist` (there can`t be two `Appointments` created for the same `Specialist` at the same time)
 - Possibility for a `Client` to check their own appointments
 - Cancelling the `Appointment` by the `Client`
 - Marking the `Appointment` as completed by the `Specialist`
@@ -394,7 +394,7 @@ Add a listener with *@PrePersist*:
 
 ----
 
-This will set the fields just before the entity is saved fort the first time.
+This will set the fields just before the entity is saved for the first time.
 Now add a second listener with *@PreUpdate*, that will only update the _lastUpdated_ field, just before executing an update query.
 
 Now you are ready to create your entities!
@@ -994,8 +994,8 @@ default List<AppointmentEntity> findByCriteria(AppointmentCriteria appointmentCr
         Root<AppointmentEntity> root = cq.from(AppointmentEntity.class);
         List<Predicate> predicates = new ArrayList<>();
 
-        if (c.status() != null) {
-            predicateList.add(builder.like(root.get("status"), c.status().name()));
+        if (appointmentCriteria.status() != null) {
+            predicates.add(cb.equal(root.get("status"), appointmentCriteria.status().name()));
         }
 
         // another predicates

--- a/appointment-booking-service-services-layer.asciidoc
+++ b/appointment-booking-service-services-layer.asciidoc
@@ -4,7 +4,7 @@
 
 = Appointment Booking System - Services Layer
 
-In this chapper we are going to create the services layer of the appointment booking system. The services layer is responsible for handling requests from the outside of the backend (e.g. from the presentation layer or from external systems) and orchestrating the interaction between the business logic layer and the external systems. It provides a set of services that can be used by the external systems to perform various operations related to appointment booking.
+In this chapter we are going to create the services layer of the appointment booking system. The services layer is responsible for handling requests from the outside of the backend (e.g. from the presentation layer or from external systems) and orchestrating the interaction between the business logic layer and the external systems. It provides a set of services that can be used by the external systems to perform various operations related to appointment booking.
 
 toc::[]
 
@@ -169,7 +169,7 @@ After running the plugin, verify that the generated code is available in the `ta
 
 The generated classes for representing the API models differ from the Eto and Cto classes provided by the business logic layer. To convert between these two representations, we need to implement mappers that will handle the conversion between the API models and the business logic layer models.
 
-To simplify the implementation, we provide the mappers. Please coppy following files to the `com.capgemini.training.appointmentbooking.service.mapper` package.
+To simplify the implementation, we provide the mappers. Please copy following files to the `com.capgemini.training.appointmentbooking.service.mapper` package.
 
 - link:assets/service/AppointmentApiMapper.java[AppointmentApiMapper.java]
 - link:assets/service/TreatmentApiMapper.java[TreatmentApiMapper.java]
@@ -186,7 +186,7 @@ To be familiar with the generated code, open the `com.capgemini.training.appoint
 - `AppointmentApi.java`: This interface defines the API for managing appointments.
 
 
-Pleas try to complete the implementation of at least one of the APIs. If you have more time you can implement the second API as well.
+Please try to complete the implementation of at least one of the APIs. If you have more time you can implement the second API as well.
 
 === Implementing the TreatmentApi
 
@@ -231,13 +231,13 @@ return ResponseEntity.status(HttpStatus.CREATED).body(treatmentMapper.toApiTreat
 ----
 
 If a treatment is not found, return a `404 Not Found` response.
-If an error occurs during the operation, return a `500 Internal Server Error` response with an appropriate error message. Refer the Openapi specification to ensure the metyhods return the correct HTTP status codes and response formats.
+If an error occurs during the operation, return a `500 Internal Server Error` response with an appropriate error message. Refer the Openapi specification to ensure the methods return the correct HTTP status codes and response formats.
 
 You can also check the generated inferfaces for the `AppointmentApi` and `TreatmentApi` to see the expected request and response formats.
 
 While implementing the controllers, you need to test the services layer to ensure that the implementation is correct. 
 
-- You can use the `MockMvc` framework to test the controllers. Please refer to the link:#implementing-the-tests[Implementing the Tesst] section for more details on how to implement the test cases for the services layer.
+- You can use the `MockMvc` framework to test the controllers. Please refer to the link:#implementing-the-tests[Implementing the Test] section for more details on how to implement the test cases for the services layer.
 - You can use Swagger to test the API endpoints. Swagger provides a user interface that allows you to test the API endpoints directly from the browser. Please refer link:#testing-the-services-layer[Testing the Services Layer]  for more details on how to test the services layer.
 
 
@@ -297,7 +297,7 @@ In this task you can add input validation to your services. Utilize annotations 
 
 Please follow _Bean validation using Hibernate Validator_ in link:appointment-booking-service-business-logic-layer.asciidoc#optional-bean-validation-using-hibernate-validator[Appointment Booking System - Business Logic Layer] for more details. 
 
-If you need to add more validation constraints to the requesst you need to update the OpenAPI specification and regenerate the code. Please refer the Openapi documentation for more details.
+If you need to add more validation constraints to the request you need to update the OpenAPI specification and regenerate the code. Please refer the Openapi documentation for more details.
 
 
 == Testing the Services Layer


### PR DESCRIPTION
This PR resolves issue #8 by fixing the example code that referenced undefined variables (e.g., c.status()). Additionally, minor typos were corrected