### PR TITLE
Fix appointment search query to match task requirements (#12)

### DIFF
--- a/appointment-booking-service-dataaccess-layer.asciidoc
+++ b/appointment-booking-service-dataaccess-layer.asciidoc
@@ -919,10 +919,10 @@ Directly in the interface create a new method with a @Query annotation and JQPL 
             SELECT a FROM AppointmentEntity a
             JOIN a.treatment t
             WHERE t.specialist.id = :specialistId
-            AND a.dateTime < :date
+            AND a.dateTime < CURRENT_TIMESTAMP
             ORDER BY a.dateTime DESC
             """)
-    List<AppointmentEntity> findAppointmentsBySpecialistIdBeforeDate(@Param("specialistId") Long specialistId, @Param("date") Instant date);
+    List<AppointmentEntity> findAppointmentsBySpecialistIdBeforeDate(@Param("specialistId") Long specialistId);
 
 ----
 


### PR DESCRIPTION
Fixed the `findAppointmentsBySpecialistIdBeforeDate` method to properly implement the task requirement: "Find all Appointments for specific Specialist(Id) which took place in the past".

- Removed unnecessary `date` parameter from method signature
- Changed query condition from `AND a.dateTime < :date` to `AND a.dateTime < CURRENT_TIMESTAMP`

Fixes #12